### PR TITLE
BF: import-dcm didn't import metalad commands

### DIFF
--- a/datalad_hirni/commands/dicom2spec.py
+++ b/datalad_hirni/commands/dicom2spec.py
@@ -25,6 +25,10 @@ from datalad_hirni.support.spec_helpers import (
     has_specval
 )
 
+# bound dataset method
+import datalad_metalad.dump
+
+
 lgr = logging.getLogger('datalad.hirni.dicom2spec')
 
 

--- a/datalad_hirni/commands/import_dicoms.py
+++ b/datalad_hirni/commands/import_dicoms.py
@@ -26,6 +26,8 @@ from datalad.dochelpers import exc_str
 
 # bound dataset method
 import datalad_hirni.commands.dicom2spec
+import datalad_metalad.aggregate
+import datalad_metalad.dump
 import datalad.interface.download_url
 
 import logging

--- a/datalad_hirni/commands/spec4anything.py
+++ b/datalad_hirni/commands/spec4anything.py
@@ -1,6 +1,7 @@
 """Create specification snippets for arbitrary paths"""
 
 
+import os.path as op
 import posixpath
 from six import text_type
 
@@ -18,8 +19,9 @@ from datalad.support import json_py
 from datalad.utils import assure_list
 from datalad.interface.annotate_paths import AnnotatePaths
 from datalad.interface.results import get_status_dict
-from datalad.coreapi import metadata
-import os.path as op
+
+# bound dataset method
+import datalad_metalad.dump
 
 import logging
 lgr = logging.getLogger('datalad.hirni.spec4anything')


### PR DESCRIPTION
This led to an AttributeError when calling metalad commands as Dataset methods, when running import-dcm from CLI