### PR TITLE
Some fixes

### DIFF
--- a/datalad_hirni/commands/import_dicoms.py
+++ b/datalad_hirni/commands/import_dicoms.py
@@ -111,17 +111,12 @@ def _create_subds_from_tarball(tarball, targetdir):
     importds.save(op.join(".datalad", "config"),
                   message="[HIRNI] initial config for DICOM metadata")
 
-    importds.meta_aggregate()
-
-    # TODO: DON'T FAIL! MAY BE EVEN GET FROM SUPER?
-    # XXX why is this done at all? if needed, why hard-coded URL?
-    # importds.install(path=opj(".datalad", "environments", "import-container"),
-    #                  source="http://psydata.ovgu.de/cbbs-imaging/conv-container/.git")
-
     return importds
 
 
 def _guess_acquisition_and_move(ds, target_ds):
+
+    ds.meta_aggregate()
     res = ds.meta_dump(
         reporton='datasets',
         return_type='item-or-list',

--- a/datalad_hirni/commands/import_dicoms.py
+++ b/datalad_hirni/commands/import_dicoms.py
@@ -129,8 +129,10 @@ def _guess_acquisition_and_move(ds, target_ds):
     # there should be exactly one result and therefore a dict
     assert isinstance(res, dict)
 
+    # TODO: Move default to config definition
+    #       This requires a general mechanism to plugin an extension's config specs
     format_string = \
-        target_ds.config.get("datalad.hirni.import.acquisition-format")
+        target_ds.config.get("datalad.hirni.import.acquisition-format", default="{PatientID}")
     # Note: simply the metadata dict for first Series herein is passed into
     # format ATM.
     # TODO: Eventually make entire result from `metadata` available.

--- a/datalad_hirni/commands/spec4anything.py
+++ b/datalad_hirni/commands/spec4anything.py
@@ -36,7 +36,7 @@ def _get_edit_dict(value=None, approved=False):
     return dict(approved=approved, value=value)
 
 
-def _add_to_spec(spec, spec_dir, path, meta, overrides=None, replace=False):
+def _add_to_spec(spec, spec_dir, path, ds, overrides=None, replace=False):
     """
     Parameters
     ----------
@@ -52,11 +52,12 @@ def _add_to_spec(spec, spec_dir, path, meta, overrides=None, replace=False):
       key, values to add/overwrite the default
     """
 
+    from datalad_metalad import get_refcommit
     snippet = {
         'type': 'generic_' + path['type'],
         'location': posixpath.relpath(path['path'], spec_dir),
-        'dataset-id': meta['dsid'],
-        'dataset-refcommit': meta['refcommit'],
+        'dataset-id': ds.id,
+        'dataset-refcommit': get_refcommit(ds),
         'id': _get_edit_dict(),
         'procedures': _get_edit_dict(),
         'comment': _get_edit_dict(value=""),
@@ -140,10 +141,6 @@ class Spec4Anything(Interface):
 
         res_kwargs = dict(action='hirni spec4anything', logger=lgr)
         res_kwargs['refds'] = Interface.get_refds_path(dataset)
-
-        ds_meta = dataset.meta_dump(reporton='datasets',
-                                    return_type='item-or-list',
-                                    result_renderer='disabled')
 
         # ### This might become superfluous. See datalad-gh-2653
         ds_path = PathRI(dataset.path)
@@ -262,7 +259,7 @@ class Spec4Anything(Interface):
             # But then: This should concern non-editable fields only, right?
 
             spec = _add_to_spec(spec, posixpath.split(spec_path)[0], ap,
-                                ds_meta, overrides=overrides, replace=replace)
+                                dataset, overrides=overrides, replace=replace)
 
             # Note: Not sure whether we really want one commit per snippet.
             #       If not - consider:

--- a/datalad_hirni/resources/procedures/cfg_hirni.py
+++ b/datalad_hirni/resources/procedures/cfg_hirni.py
@@ -85,7 +85,6 @@ ds.install(path=op.join("code", "hirni-toolbox"),
 
 # Include a basic top-level spec file, that specifies "copy-conversion" for
 # README and dataset_description.json
-ds.meta_aggregate()  # TODO: Forgot why
 ds.hirni_spec4anything(path='README',
                        spec_file='studyspec.json',
                        properties={


### PR DESCRIPTION
- [x] BF: Don't crash if format string isn't configured
- [x] RF: spec4anything shouldn't need metadata and by extension `cfg_hirni` no aggregation (see #116)
- [x] Double aggregation only when needed (see #117 )
