### PR TITLE
Prepare release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ would recommend to consult log of the [Git
 repository](http://github.com/psychoinformatics-de/datalad-hirni) for more
 details.
 
+## 0.0.5 (January 8, 2020)
+- lots of bugfixes
+- enhance documentation
+- work with datalad >= 0.12.0rc6
+
 ## 0.0.3 (May 24, 2019) -- We're getting there
 - rework rule system for easier customization and configurability
 - config routine setup_hirni_dataset renamed to cfg_hirni

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ a dedicated [virtualenv](https://virtualenv.pypa.io):
 
 The documentation of this project is found here:
 http://docs.datalad.org/projects/hirni
+The documentation is built from this very repository's files under ``docs/source`` and thus you can contribute to the
+docs by opening a pull request just like you'd contribute to the code itself.
 
 All bugs, concerns and enhancement requests for this software can be submitted here:
 https://github.com/psychoinformatics-de/datalad-hirni/issues

--- a/datalad_hirni/commands/dicom2spec.py
+++ b/datalad_hirni/commands/dicom2spec.py
@@ -464,10 +464,15 @@ class Dicom2Spec(Interface):
         # spec_series_list = sorted(spec_series_list, key=lambda x: sort_spec(x))
         json_py.dump2stream(spec_series_list, spec)
 
-        # make sure spec is in git:
-        dataset.repo.set_gitattributes([(spec,
-                                         {'annex.largefiles': 'nothing'})],
-                                       '.gitattributes')
+        # make sure spec is tracked in git:
+        spec_attrs = dataset.repo.get_gitattributes(spec)
+        spec_relpath = op.relpath(spec, dataset.path)
+        if spec_relpath not in spec_attrs.keys() or \
+                'annex.largefiles' not in spec_attrs[spec_relpath].keys() or \
+                spec_attrs[spec_relpath]['annex.largefiles'] != 'nothing':
+            dataset.repo.set_gitattributes([(spec,
+                                             {'annex.largefiles': 'nothing'})],
+                                           '.gitattributes')
 
         for r in Save.__call__(dataset=dataset,
                                path=[spec, '.gitattributes'],

--- a/datalad_hirni/tests/test_demos.py
+++ b/datalad_hirni/tests/test_demos.py
@@ -24,7 +24,8 @@ from datalad.tests.utils import (
     ok_file_under_git,
     assert_repo_status,
     assert_true,
-    skip_if_on_windows
+    skip_if_on_windows,
+    SkipTest
 )
 
 
@@ -168,6 +169,8 @@ def test_demo_repro_analysis(bids_path, ana_path):
                     cmd='bash code/events2ev3.sh sub-001 {inputs}',
                     message="Build FSL EV3 design files"
                     )
+
+    raise SkipTest("Solve datalad-containers #115")
 
     analysis_ds.containers_add('fsl', url="shub://ReproNim/ohbm2018-training:fsln")
     #   % datalad containers-list

--- a/datalad_hirni/tests/test_dicom2spec.py
+++ b/datalad_hirni/tests/test_dicom2spec.py
@@ -268,3 +268,9 @@ def test_dicom2spec(path):
     assert_result_count(res, 1, path=op.join(ds.path, 'spec_structural.json'))
     assert_result_count(res, 1, path=op.join(ds.path, '.gitattributes'))
     ok_clean_git(ds.path)
+
+    # multiple execution shouldn't change .gitattributes again:
+    from os import stat
+    mtime = stat(op.join(ds.path, '.gitattributes')).st_mtime
+    res = ds.hirni_dicom2spec(path='acq100', spec='spec_structural.json')
+    assert_equal(stat(op.join(ds.path, '.gitattributes')).st_mtime, mtime)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,13 @@ We would recommend to consult log of the `Git
 repository <http://github.com/psychoinformatics-de/datalad-hirni>`__ for
 more details.
 
+0.0.5 (January 8, 2020)
+-----------------------
+
+-  lots of bugfixes
+-  enhance documentation
+-  work with datalad >= 0.12.0rc6
+
 0.0.3 (May 24, 2019) – We’re getting there
 ------------------------------------------
 

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -78,7 +78,11 @@ the conversion command. That way the default defacing - which also can be replac
 implemented, for example.
 
 
+For a more detailed explanation of how it works and how to approach customization, you might be interested in watching
+this talk_.
+
+
 .. _dataset: https://datalad.readthedocs.io/en/latest/glossary.html
 .. _run: https://datalad.readthedocs.io/en/latest/generated/man/datalad-run.html
 .. _YODA: https://doi.org/10.7490/f1000research.1116363.1
-
+.. _talk: https://vimeo.com/380036896/afaf850c38


### PR DESCRIPTION
This release should most importantly lead to compatibility with datalad 0.12.0rc6+, the lack thereof shown particularly in #129 and #150. Fix for that is in master already, release needs to make sure it's actually available, get dependencies right and include some minor fixes while at it.