### PR TITLE
Prepare minor release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ install:
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
   - cd ..; pip install -q codecov; cd -
-  - pip install -r requirements-devel.txt
+  # don't regularly test against master branches of datalad & extensions
+  #- pip install -r requirements-devel.txt
   # So we could test under sudo -E with PATH pointing to installed location
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -2,3 +2,4 @@
 -e git+https://github.com/datalad/datalad-neuroimaging.git#egg=datalad_neuroimaging
 -e git+https://github.com/datalad/datalad-container.git#egg=datalad_container
 -e git+https://github.com/datalad/datalad-metalad.git#egg=datalad_metalad
+-e git+https://github.com/datalad/datalad-webapp.git#egg=datalad_webapp

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ setup(
     zip_safe=False,
     # datalad command suite specs from here
     install_requires=[
-        'datalad[full]>=0.12.0rc4',
+        'datalad[full]>=0.12.5',
         'datalad-metalad>=0.2.0',
         'datalad-neuroimaging',
         'datalad-container>=0.5.2',
-        'datalad-webapp',
+        'datalad-webapp>=0.3',
     ],
     extras_require={
         'devel-docs': [


### PR DESCRIPTION
- test against released versions of datalad and extensions instead of their master branches
- depend on datalad 0.12.5 and webapp 0.3