### PR TITLE
RF: Use call_git() in favor of _git_custom_command()

### DIFF
--- a/datalad_hirni/commands/import_dicoms.py
+++ b/datalad_hirni/commands/import_dicoms.py
@@ -64,7 +64,7 @@ def _import_dicom_tarball(target_ds, tarball, filename):
 
     target_ds.repo.merge('incoming', options=["-s", "ours", "--no-commit"],
                          expect_stderr=True)
-    target_ds.repo._git_custom_command([], "git read-tree -m -u incoming")
+    target_ds.repo.call_git(['read-tree', '-m', '-u', 'incoming'])
 
     from datalad.coreapi import add_archive_content
     # # TODO: Reconsider value of --existing


### PR DESCRIPTION
which will go away soon.