### PR TITLE
BF: modify template dataset_description.json

### DIFF
--- a/datalad_hirni/resources/procedures/cfg_hirni.py
+++ b/datalad_hirni/resources/procedures/cfg_hirni.py
@@ -58,7 +58,7 @@ bids_description = {
     "Authors": [],
     "Acknowledgements": "",
     "HowToAcknowledge": "",
-    "Funding": "",
+    "Funding": [],
     "ReferencesAndLinks": [],
     "DatasetDOI": "",
     "Ethics": "",


### PR DESCRIPTION
Funding should be an array rather than a string in order to be BIDS compliant.

Closes #167