### PR TITLE
DOC: demo_reproducibility.rst: Update download-url call

### DIFF
--- a/docs/source/demos/demo_reproducibility.rst
+++ b/docs/source/demos/demo_reproducibility.rst
@@ -85,7 +85,7 @@ Before we can fire up FSL for our GLM analysis, we need two pieces of custom cod
 Any custom code needs to be tracked if we want to achieve a complete record of how an analysis was conducted. Hence we will store those scripts in our analysis dataset.
 We use the `datalad download-url` command to download the scripts and include them in the analysis dataset::
 
-  % datalad download-url --path code \
+  % datalad download-url --path code/ \
   https://raw.githubusercontent.com/myyoda/ohbm2018-training/master/section23/scripts/events2ev3.sh \
   https://raw.githubusercontent.com/myyoda/ohbm2018-training/master/section23/scripts/ffa_design.fsf
 


### PR DESCRIPTION
Since Datalad 0.12, specifically de9d692318 (ENH: download_url: Use
trailing separator to signal directory target, 2019-11-01), a
directory argument for --path requires a trailing slash.

Re: datalad/datalad#5528